### PR TITLE
Copy lua files

### DIFF
--- a/build/cyan/commands/build.lua
+++ b/build/cyan/commands/build.lua
@@ -81,7 +81,10 @@ local function build(args, loaded_config, starting_dir)
    end
 
    local include = loaded_config.include or {}
-   local exclude = loaded_config.exclude or {}
+   local exclude = loaded_config.exclude and { _tl_table_unpack(loaded_config.exclude) } or {}
+   if source_dir == starting_dir then
+      table.insert(exclude, "tlconfig.lua")
+   end
 
    local dag, cycles = graph.scan_dir(source_dir, include, exclude)
    if not dag then

--- a/build/cyan/commands/build.lua
+++ b/build/cyan/commands/build.lua
@@ -103,8 +103,10 @@ local function build(args, loaded_config, starting_dir)
       local out = src:copy()
       out:remove_leading(source_dir)
       out:prepend(build_dir)
-      local base = fs.extension_split(out[#out])
-      out[#out] = base .. ".lua"
+      local base, ext = fs.extension_split(out[#out])
+      if ext == ".tl" then
+         out[#out] = base .. ".lua"
+      end
       return out
    end
 

--- a/build/cyan/fs/init.lua
+++ b/build/cyan/fs/init.lua
@@ -177,4 +177,25 @@ function fs.search_parent_dirs(start_path, fname)
    end
 end
 
+
+
+
+
+function fs.copy(source, dest)
+   local source_path = ensure(source, true)
+   local dest_path = ensure(dest, true)
+
+   local source_contents, read_err = fs.read(source_path:to_real_path())
+   if not source_contents then
+      return false, read_err
+   end
+   local fh, open_err = io.open(dest_path:to_real_path(), "r")
+   if not fh then
+      return false, open_err
+   end
+   fh:write(source_contents)
+   fh:close()
+   return true
+end
+
 return fs

--- a/build/cyan/fs/path.lua
+++ b/build/cyan/fs/path.lua
@@ -194,11 +194,25 @@ function Path:prepend(other)
    if self:is_absolute() then
       error("Attempt to prepend to absolute path", 2)
    end
-   local i = 1
-   for chunk in chunks(other) do
-      table.insert(self, i, chunk)
-      i = i + 1
+   other = path.ensure(other)
+   local other_len = #other
+   table.move(self, 1, #self, other_len + 1)
+   for i = 1, other_len do
+      self[i] = other[i]
    end
+end
+
+
+
+
+
+
+
+function Path:to_absolute()
+   if self:is_absolute() then
+      return
+   end
+   self:prepend(lfs.currentdir())
 end
 
 
@@ -329,8 +343,11 @@ function Path.eq(a, b, use_os_sep)
       return true
    end
 
-   local pa = type(a) == "string" and parse_string_path(a, use_os_sep) or a
-   local pb = type(b) == "string" and parse_string_path(b, use_os_sep) or b
+   local pa = type(a) == "string" and path.new(a, use_os_sep) or (a):copy()
+   local pb = type(b) == "string" and path.new(b, use_os_sep) or (b):copy()
+
+   pa:to_absolute()
+   pb:to_absolute()
 
    if rawlen(pa) ~= rawlen(pb) then
       return false

--- a/build/cyan/graph.lua
+++ b/build/cyan/graph.lua
@@ -174,11 +174,7 @@ local function unchecked_insert(dag, f, in_dir)
 
       return
    end
-   local _, ext = fs.extension_split(f, 2)
-   if ext ~= ".tl" then
 
-      return
-   end
    local res = common.parse_file(real_path)
    if not res then return end
    local n = make_node(f)
@@ -267,7 +263,7 @@ function graph.scan_dir(dir, include, exclude)
    dir = fs.path.ensure(dir)
    for p in fs.scan_dir(dir, include, exclude) do
       local _, ext = fs.extension_split(p, 2)
-      if ext == ".tl" then
+      if ext == ".tl" or ext == ".lua" then
          unchecked_insert(d, dir .. p, dir)
       end
    end

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,6 +85,7 @@ h2 {
 <br><a href=index.html#Path:prepend>Path:prepend</a>
 <br><a href=index.html#Path:relative_to>Path:relative_to</a>
 <br><a href=index.html#Path:remove_leading>Path:remove_leading</a>
+<br><a href=index.html#Path:to_absolute>Path:to_absolute</a>
 <br><a href=index.html#Path:to_real_path>Path:to_real_path</a>
 <br><a href=index.html#Path:tostring>Path:tostring</a>
 <br><a href=index.html#Path>Path</a>
@@ -250,7 +251,9 @@ h2 {
 </h2>
 <p>Expresses a path in terms of another path. If any relative paths are given, they are treated as though they are in the current directory</p><p>for example: <code>path.new(<code>"/foo/bar/baz"</code>):relative_to(path.new(<code>"/foo/bat"</code>)) == path.new <code>"../bar/baz"</code></code></p><h2><a name=Path:remove_leading><code>Path:remove_leading(p: string | Path)</code></a>
 </h2>
-<p>Mutate the given path by removing the leading parts from the given path</p><p>Will error if you attempt to mix absolute and non-absolute paths</p><h2><a name=Path:to_real_path><code>Path:to_real_path(): string</code></a>
+<p>Mutate the given path by removing the leading parts from the given path</p><p>Will error if you attempt to mix absolute and non-absolute paths</p><h2><a name=Path:to_absolute><code>Path:to_absolute()</code></a>
+</h2>
+<p>Modify a path in place to become an absolute path</p><p>When the path is already absolute, does nothing</p><p>Otherwise, prepends the current directory</p><h2><a name=Path:to_real_path><code>Path:to_real_path(): string</code></a>
 </h2>
 <p>Convert a <code>Path</code> to a string describing a real path</p><h2><a name=Path:tostring><code>Path:tostring(): string</code></a>
 </h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,7 @@ h2 {
 </p>
 <p><a href=index.html#cyan.fs>cyan.fs</a>
 <br><a href=index.html#fs.chdir>fs.chdir</a>
+<br><a href=index.html#fs.copy>fs.copy</a>
 <br><a href=index.html#fs.cwd>fs.cwd</a>
 <br><a href=index.html#fs.dir>fs.dir</a>
 <br><a href=index.html#fs.extension_split>fs.extension_split</a>
@@ -264,7 +265,9 @@ h2 {
 </h1>
 <p>Filesystem and path management</p><h2><a name=fs.chdir><code>fs.chdir(p: string | Path): boolean, string</code></a>
 </h2>
-<p>Change the current directory to <code>p</code></p><h2><a name=fs.cwd><code>fs.cwd(): Path</code></a>
+<p>Change the current directory to <code>p</code></p><h2><a name=fs.copy><code>fs.copy(source: string | Path, dest: string | Path): boolean, string</code></a>
+</h2>
+<p>Copy a file</p><p>uses <code>fs.read</code> internally to get and cache the contents of <code>source</code></p><h2><a name=fs.cwd><code>fs.cwd(): Path</code></a>
 </h2>
 <p>Get the current working directory as an <code>fs.Path</code></p><h2><a name=fs.dir><code>fs.dir(dir: string | Path, include_dotfiles: boolean): function(): Path</code></a>
 </h2>

--- a/spec/commands/build_spec.lua
+++ b/spec/commands/build_spec.lua
@@ -225,7 +225,7 @@ describe("build command", function()
          cmd_output_match = [[Unexpected files in build directory]],
       })
    end)
-   it("#f should copy lua files from the source directory to the build directory", function()
+   it("should copy lua files from the source directory to the build directory", function()
       util.run_mock_project(finally, {
          cmd = "build",
          dir_structure = {

--- a/spec/commands/build_spec.lua
+++ b/spec/commands/build_spec.lua
@@ -225,6 +225,23 @@ describe("build command", function()
          cmd_output_match = [[Unexpected files in build directory]],
       })
    end)
+   it("#f should copy lua files from the source directory to the build directory", function()
+      util.run_mock_project(finally, {
+         cmd = "build",
+         dir_structure = {
+            [util.configfile] = [[return { build_dir = "build", source_dir = "src" }]],
+            build = {},
+            src = {
+               ["foo.lua"] = [[print "foo"]],
+               ["bar.tl"] = [[print "bar"]],
+            },
+         },
+         exit_code = 0,
+         generated_files = {
+            build = { "foo.lua", "bar.lua" },
+         },
+      })
+   end)
    describe("script hooks", function()
       it("should emit a build:pre hook before doing any actions", function()
          util.run_mock_project(function() end, {

--- a/src/cyan/commands/build.tl
+++ b/src/cyan/commands/build.tl
@@ -81,7 +81,10 @@ local function build(args: command.Args, loaded_config: config.Config, starting_
    end
 
    local include <const> = loaded_config.include or {}
-   local exclude <const> = loaded_config.exclude or {}
+   local exclude <const> = loaded_config.exclude and { table.unpack(loaded_config.exclude) } or {}
+   if source_dir == starting_dir then
+      table.insert(exclude, "tlconfig.lua")
+   end
 
    local dag <const>, cycles <const> = graph.scan_dir(source_dir, include, exclude)
    if not dag then

--- a/src/cyan/commands/build.tl
+++ b/src/cyan/commands/build.tl
@@ -103,8 +103,10 @@ local function build(args: command.Args, loaded_config: config.Config, starting_
       local out <const> = src:copy()
       out:remove_leading(source_dir)
       out:prepend(build_dir)
-      local base <const> = fs.extension_split(out[#out])
-      out[#out] = base .. ".lua"
+      local base <const>, ext <const> = fs.extension_split(out[#out])
+      if ext == ".tl" then
+         out[#out] = base .. ".lua"
+      end
       return out
    end
 

--- a/src/cyan/fs/init.tl
+++ b/src/cyan/fs/init.tl
@@ -177,4 +177,25 @@ function fs.search_parent_dirs(start_path: string | Path, fname: string): Path
    end
 end
 
+---@desc
+--- Copy a file
+---
+--- uses `fs.read` internally to get and cache the contents of `source`
+function fs.copy(source: string | Path, dest: string | Path): boolean, string
+   local source_path <const> = ensure(source, true)
+   local dest_path <const> = ensure(dest, true)
+
+   local source_contents <const>, read_err <const> = fs.read(source_path:to_real_path())
+   if not source_contents then
+      return false, read_err
+   end
+   local fh <const>, open_err <const> = io.open(dest_path:to_real_path(), "r")
+   if not fh then
+      return false, open_err
+   end
+   fh:write(source_contents)
+   fh:close()
+   return true
+end
+
 return fs

--- a/src/cyan/fs/path.tl
+++ b/src/cyan/fs/path.tl
@@ -343,14 +343,17 @@ function Path.eq(a: Path | string, b: Path | string, use_os_sep: boolean): boole
       return true
    end
 
-   local pa <const> = a is string and parse_string_path(a, use_os_sep) or a as Path
-   local pb <const> = b is string and parse_string_path(b, use_os_sep) or b as Path
+   local pa <const> = a is string and path.new(a, use_os_sep) or (a as Path):copy()
+   local pb <const> = b is string and path.new(b, use_os_sep) or (b as Path):copy()
 
-   if rawlen(pa) ~= rawlen(pb) then
+   pa:to_absolute()
+   pb:to_absolute()
+
+   if rawlen(pa as {string}) ~= rawlen(pb as {string}) then
       return false
    end
 
-   for i = 1, rawlen(pa) do
+   for i = 1, rawlen(pa as {string}) do
       if rawget(pa, i) ~= rawget(pb, i) then
          return false
       end

--- a/src/cyan/fs/path.tl
+++ b/src/cyan/fs/path.tl
@@ -194,10 +194,14 @@ function Path:prepend(other: string | Path)
    if self:is_absolute() then
       error("Attempt to prepend to absolute path", 2)
    end
-   local i = 1
-   for chunk in chunks(other) do
-      table.insert(self, i, chunk)
-      i = i + 1
+   other = path.ensure(other)
+   local other_len <const> = #other
+   table.move(self, 1, #self, other_len + 1)
+   for i = 1, other_len do
+      self[i] = other[i]
+   end
+end
+
    end
 end
 

--- a/src/cyan/fs/path.tl
+++ b/src/cyan/fs/path.tl
@@ -202,7 +202,17 @@ function Path:prepend(other: string | Path)
    end
 end
 
+---@desc
+--- Modify a path in place to become an absolute path
+---
+--- When the path is already absolute, does nothing
+---
+--- Otherwise, prepends the current directory
+function Path:to_absolute()
+   if self:is_absolute() then
+      return
    end
+   self:prepend(lfs.currentdir())
 end
 
 ---@desc

--- a/src/cyan/graph.tl
+++ b/src/cyan/graph.tl
@@ -174,11 +174,7 @@ local function unchecked_insert(dag: Dag, f: fs.Path, in_dir: fs.Path)
       -- We already have this in the graph
       return
    end
-   local _, ext <const> = fs.extension_split(f, 2)
-   if ext ~= ".tl" then
-      -- we dont care about non Teal stuff
-      return
-   end
+
    local res <const> = common.parse_file(real_path)
    if not res then return end
    local n <const>: Node = make_node(f)
@@ -267,7 +263,7 @@ function graph.scan_dir(dir: string | fs.Path, include: {string}, exclude: {stri
    dir = fs.path.ensure(dir)
    for p in fs.scan_dir(dir, include, exclude) do
       local _, ext = fs.extension_split(p, 2)
-      if ext == ".tl" then
+      if ext == ".tl" or ext == ".lua" then
          unchecked_insert(d, dir .. p, dir)
       end
    end


### PR DESCRIPTION
[just copying the relevant commit message]

> `Feature request: Copy any lua files found in source directory into build
> directory`
>
> Currently the main thing blocking this is the fact that `tlconfig.lua`
> is a lua file itself that we want to ignore universally. There are two
> solutions that I see:
>  1. Break compatability with `tl` and call the config file something
>    different.
>  2. Only copy lua files when `source_dir` is not `./`
>
> Neither of these feel very good to me but 2 seems better