### PR TITLE
ci: bump versions of gh-actions-lua,luarocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@main
 
       - name: Install Lua
-        uses: leafo/gh-actions-lua@v8.0.0
+        uses: leafo/gh-actions-lua@v10.0.0
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
       - name: Install LuaRocks
-        uses: leafo/gh-actions-luarocks@v4.0.0
+        uses: leafo/gh-actions-luarocks@v4.3.0
 
       - name: Build
         run: |


### PR DESCRIPTION
These were downloading a very old version of LuaRocks which no longer works due to changes in the GitHub authentication system.

Fixes #33.

These are the latest versions, I wonder if we should just point to the master branches of each action...