### PR TITLE
make ts.require call compatible with tree-sitter-teal rock

### DIFF
--- a/scripts/gen_documentation.tl
+++ b/scripts/gen_documentation.tl
@@ -17,7 +17,7 @@ if not has_ltreesitter then
    return
 end
 
-local has_teal_parser <const>, teal_parser <const> = pcall(ts.require, "teal", nil)
+local has_teal_parser <const>, teal_parser <const> = pcall(ts.require, "parser/teal", "teal")
 if not has_teal_parser then
    log.warn("docgen requires tree-sitter-teal, which ltreesitter could not find:\n", teal_parser as string)
    return

--- a/scripts/lint.tl
+++ b/scripts/lint.tl
@@ -21,7 +21,7 @@ local function lint()
       return
    end
 
-   local has_teal_parser <const>, teal_parser <const> = pcall(ts.require, "teal", nil)
+   local has_teal_parser <const>, teal_parser <const> = pcall(ts.require, "parser/teal", "teal")
    if not has_teal_parser then
       warn("lint requires tree-sitter-teal, which ltreesitter could not find:\n", teal_parser as string)
       return


### PR DESCRIPTION
If one builds the dependencies with LuaRocks doing

```
luarocks install ltreesitter
luarocks install tree-sitter-teal
```

The resulting parser gets installed in `lib/lua/5.x/parser/teal.so`.

Perhaps instead of this change, which includes a Unixy `/` path and probably breaks someone else's setup, ltreesitter should be changed instead, to make it automatically search within a `parser` directory when doing its Lua package.cpath search.