### PR TITLE
Fix sorting bug in directories comparison

### DIFF
--- a/build/cyan/commands/build.lua
+++ b/build/cyan/commands/build.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local coroutine = _tl_compat and _tl_compat.coroutine or coroutine; local io = _tl_compat and _tl_compat.io or io; local os = _tl_compat and _tl_compat.os or os; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local coroutine = _tl_compat and _tl_compat.coroutine or coroutine; local io = _tl_compat and _tl_compat.io or io; local os = _tl_compat and _tl_compat.os or os; local pairs = _tl_compat and _tl_compat.pairs or pairs; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
 
 local argparse = require("argparse")
 local tl = require("tl")
@@ -287,8 +287,10 @@ local function build(args, loaded_config, context)
       table.sort(unexpected_directories, function(a, b)
          local a_str = a:to_string()
          local b_str = b:to_string()
-         if #a_str > #b_str then
-            return true
+         local a_len = #a_str
+         local b_len = #b_str
+         if a_len ~= b_len then
+            return a_len > b_len
          end
          return a_str > b_str
       end)

--- a/src/cyan/commands/build.tl
+++ b/src/cyan/commands/build.tl
@@ -287,8 +287,10 @@ local function build(args: command.Args, loaded_config: config.Config, context: 
       table.sort(unexpected_directories, function(a: lexical_path.Path, b: lexical_path.Path): boolean
          local a_str <const> = a:to_string()
          local b_str <const> = b:to_string()
-         if #a_str > #b_str then
-            return true
+         local a_len <const> = #a_str
+         local b_len <const> = #b_str
+         if a_len ~= b_len then
+            return a_len > b_len
          end
          return a_str > b_str
       end)


### PR DESCRIPTION
The original comparison function had an issue where it would return true immediately when a_str was longer than b_str, without checking the actual string comparison. This led to me getting consistent build failures. The fix properly compares lengths first, then falls back to lexicographic comparison only when lengths are equal.